### PR TITLE
Add JetBrains IDE files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ ehthumbs_vista.db
 .vscode/
 *.swo
 *.swp
+
+# Jetbrains IDE files
+.idea/


### PR DESCRIPTION
For reference, this exists in other godotengine repositories. Examples:

- https://github.com/godotengine/godot/blob/215acd52e82f4c575abb715e25e54558deeef998/.gitignore#L159
- https://github.com/godotengine/godot-docs/blob/4fc8c58cf0b32d54e4629ef8dadedefa3e0b5c72/.gitignore#L62
- https://github.com/godotengine/godot-demo-projects/blob/f7a14337394085aa89576bf4e258c51f268e725f/.gitignore#L25
